### PR TITLE
Add basic unit tests for SDK and broker

### DIFF
--- a/bradax-broker/src/broker/main.py
+++ b/bradax-broker/src/broker/main.py
@@ -87,9 +87,9 @@ def create_app() -> FastAPI:
         title="bradax Broker",
         description="Runtime de IA generativa seguro e flexível para bradax AI Solutions",
         version="0.1.0",
-        docs_url="/docs" if settings.BRADAX_BROKER_DEBUG else None,
-        redoc_url="/redoc" if settings.BRADAX_BROKER_DEBUG else None,
-        openapi_url="/openapi.json" if settings.BRADAX_BROKER_DEBUG else None,
+        docs_url="/docs" if settings.debug else None,
+        redoc_url="/redoc" if settings.debug else None,
+        openapi_url="/openapi.json" if settings.debug else None,
         lifespan=lifespan
     )
     
@@ -109,10 +109,10 @@ def setup_middlewares(app: FastAPI):
     """Configura middlewares da aplicação"""
     
     # CORS - apenas para desenvolvimento local
-    if settings.BRADAX_BROKER_DEBUG:
+    if settings.debug:
         app.add_middleware(
             CORSMiddleware,
-            allow_origins=settings.BRADAX_BROKER_CORS_ORIGINS,
+            allow_origins=settings.cors_origins,
             allow_credentials=True,
             allow_methods=["GET", "POST", "PUT", "DELETE"],
             allow_headers=["*"],
@@ -121,7 +121,7 @@ def setup_middlewares(app: FastAPI):
     # Trusted hosts
     app.add_middleware(
         TrustedHostMiddleware,
-        allowed_hosts=settings.BRADAX_BROKER_ALLOWED_HOSTS
+        allowed_hosts=[settings.host]
     )
     
     # Middlewares customizados
@@ -236,11 +236,11 @@ def main():
     """Ponto de entrada principal"""
     uvicorn.run(
         "broker.main:app",
-        host=settings.BRADAX_BROKER_HOST,
-        port=settings.BRADAX_BROKER_PORT,
-        reload=settings.BRADAX_BROKER_DEBUG,
-        log_level="debug" if settings.BRADAX_BROKER_DEBUG else "info",
-        access_log=settings.BRADAX_BROKER_DEBUG,
+        host=settings.host,
+        port=settings.port,
+        reload=settings.debug,
+        log_level="debug" if settings.debug else "info",
+        access_log=settings.debug,
         loop="asyncio"
     )
 

--- a/bradax-broker/src/broker/middleware/rate_limiting.py
+++ b/bradax-broker/src/broker/middleware/rate_limiting.py
@@ -64,7 +64,6 @@ class RateLimitingMiddleware(BaseHTTPMiddleware):
         Returns:
             Response HTTP ou erro 429
         """
-        """
         
         # Obter IP do cliente
         client_ip = self._get_client_ip(request)

--- a/bradax-broker/tests/test_broker_config.py
+++ b/bradax-broker/tests/test_broker_config.py
@@ -1,0 +1,23 @@
+import importlib
+from broker.constants import HubLLMConstants
+from broker import config as cfg
+
+
+def test_settings_defaults(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'development')
+    importlib.reload(cfg)
+    settings = cfg.Settings()
+    assert settings.debug is True
+    assert settings.environment.value == 'development'
+
+
+def test_get_model_configuration():
+    cfg_obj = cfg.get_model_configuration(HubLLMConstants.DEFAULT_MODEL)
+    assert 'max_tokens' in cfg_obj
+
+
+def test_environment_helpers(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'production')
+    importlib.reload(cfg)
+    assert cfg.is_production() is True
+    assert cfg.is_development() is False

--- a/bradax-broker/tests/test_broker_constants.py
+++ b/bradax-broker/tests/test_broker_constants.py
@@ -1,0 +1,37 @@
+import importlib
+from broker.constants import (
+    get_hub_environment, BradaxEnvironment,
+    get_cors_origins, get_default_budget,
+    validate_model, get_model_limits,
+    HubNetworkConstants, HubBudgetConstants, HubLLMConstants
+)
+
+
+def test_get_hub_environment_default(monkeypatch):
+    monkeypatch.delenv('BRADAX_ENV', raising=False)
+    assert get_hub_environment() == BradaxEnvironment.DEVELOPMENT
+
+
+def test_get_hub_environment_override(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'production')
+    assert get_hub_environment() == BradaxEnvironment.PRODUCTION
+
+
+def test_get_cors_origins(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'production')
+    importlib.reload(importlib.import_module('broker.constants'))
+    from broker.constants import get_cors_origins as fresh_get_cors
+    assert fresh_get_cors() == HubNetworkConstants.CORS_ORIGINS_PROD
+
+
+def test_get_default_budget(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'staging')
+    importlib.reload(importlib.import_module('broker.constants'))
+    from broker.constants import get_default_budget as fresh_budget
+    assert fresh_budget() == HubBudgetConstants.DEFAULT_BUDGET_STAGING
+
+
+def test_validate_model_and_limits():
+    assert validate_model(HubLLMConstants.DEFAULT_MODEL)
+    limits = get_model_limits('unknown')
+    assert 'max_tokens' in limits

--- a/bradax-broker/tests/test_openai_service.py
+++ b/bradax-broker/tests/test_openai_service.py
@@ -1,0 +1,44 @@
+import types
+import sys
+import pytest
+
+
+class DummyResponse:
+    def __init__(self):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content='ok'), finish_reason='stop')]
+        self.usage = types.SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+
+
+class DummyChat:
+    async def create(self, **kwargs):
+        return DummyResponse()
+
+
+class DummyAsyncOpenAI:
+    def __init__(self, *args, **kwargs):
+        self.chat = types.SimpleNamespace(completions=DummyChat())
+
+
+sys.modules['openai'] = types.SimpleNamespace(AsyncOpenAI=DummyAsyncOpenAI)
+from broker.services import openai_service
+
+
+def patch_client(monkeypatch):
+    monkeypatch.setattr(openai_service, 'AsyncOpenAI', DummyAsyncOpenAI)
+
+
+@pytest.mark.asyncio
+async def test_invoke_llm(monkeypatch):
+    patch_client(monkeypatch)
+    service = openai_service.OpenAIService(api_key='key')
+    result = await service.invoke_llm('gpt-4o-mini', [{'role': 'user', 'content': 'hi'}])
+    assert result['model'] == 'gpt-4o-mini'
+    assert result['usage']['total_tokens'] == 2
+
+
+@pytest.mark.asyncio
+async def test_validate_api_key(monkeypatch):
+    patch_client(monkeypatch)
+    service = openai_service.OpenAIService(api_key='key')
+    valid = await service.validate_api_key()
+    assert valid is True

--- a/bradax-sdk/src/bradax/client/corporate_client.py
+++ b/bradax-sdk/src/bradax/client/corporate_client.py
@@ -115,3 +115,12 @@ class AuditLogger:
     def get_logs(self) -> List[Dict[str, Any]]:
         """Retorna logs de auditoria."""
         return self.logs.copy()
+
+
+# Alias de compatibilidade
+CorporateBradaxClient = BradaxCorporateClient
+
+
+def create_client(*args, **kwargs) -> BradaxCorporateClient:
+    """Factory simples para criar um cliente corporativo."""
+    return BradaxCorporateClient(*args, **kwargs)

--- a/bradax-sdk/src/bradax/config/sdk_config.py
+++ b/bradax-sdk/src/bradax/config/sdk_config.py
@@ -162,6 +162,32 @@ def create_project_config(
     )
 
 
+# ---------------------------------------------------------------------------
+# Helpers de configuração global
+# ---------------------------------------------------------------------------
+_GLOBAL_SDK_CONFIG: BradaxSDKConfig | None = None
+
+
+def get_sdk_config() -> BradaxSDKConfig:
+    """Retorna instância global de configuração do SDK."""
+    global _GLOBAL_SDK_CONFIG
+    if _GLOBAL_SDK_CONFIG is None:
+        _GLOBAL_SDK_CONFIG = BradaxSDKConfig()
+    return _GLOBAL_SDK_CONFIG
+
+
+def set_sdk_config(config: BradaxSDKConfig) -> None:
+    """Define configuração global do SDK."""
+    global _GLOBAL_SDK_CONFIG
+    _GLOBAL_SDK_CONFIG = config
+
+
+def reset_sdk_config() -> None:
+    """Reseta configuração global do SDK."""
+    global _GLOBAL_SDK_CONFIG
+    _GLOBAL_SDK_CONFIG = None
+
+
 def get_global_config() -> Dict[str, Any]:
     """
     Retorna configuração global consolidada.

--- a/bradax-sdk/tests/test_sdk_config.py
+++ b/bradax-sdk/tests/test_sdk_config.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+import importlib.util
+import sys
+from types import ModuleType
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / 'src' / 'bradax'
+
+# Create package placeholders with proper __path__ for relative imports
+pkg = ModuleType('bradax')
+pkg.__path__ = [str(root)]
+sys.modules['bradax'] = pkg
+cfg_pkg = ModuleType('bradax.config')
+cfg_pkg.__path__ = [str(root / 'config')]
+sys.modules['bradax.config'] = cfg_pkg
+
+# Load dependencies
+const_spec = importlib.util.spec_from_file_location('bradax.constants', root / 'constants.py')
+constants = importlib.util.module_from_spec(const_spec)
+sys.modules['bradax.constants'] = constants
+const_spec.loader.exec_module(constants)
+
+spec = importlib.util.spec_from_file_location('bradax.config.sdk_config', root / 'config' / 'sdk_config.py')
+sdk_config = importlib.util.module_from_spec(spec)
+sys.modules['bradax.config.sdk_config'] = sdk_config
+spec.loader.exec_module(sdk_config)
+
+BradaxSDKConfig = sdk_config.BradaxSDKConfig
+ProjectConfig = sdk_config.ProjectConfig
+create_sdk_config = sdk_config.create_sdk_config
+create_project_config = sdk_config.create_project_config
+SDKModelConstants = sdk_config.SDKModelConstants
+BradaxEnvironment = sdk_config.BradaxEnvironment
+
+
+def test_create_sdk_config_uses_env(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'testing')
+    config = create_sdk_config()
+    assert config.environment == BradaxEnvironment.TESTING
+    assert config.hub_url
+
+
+def test_project_config_validation_errors():
+    with pytest.raises(ValueError):
+        ProjectConfig(project_id='bad', api_key='also_bad')
+
+
+def test_create_project_config_defaults():
+    cfg = create_project_config(project_id='proj_test_123', api_key='bradax_x'*16)
+    assert cfg.name.startswith('Project')
+    assert cfg.default_model == SDKModelConstants.DEFAULT_MODEL

--- a/bradax-sdk/tests/test_sdk_constants.py
+++ b/bradax-sdk/tests/test_sdk_constants.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from types import ModuleType
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / 'src' / 'bradax' / 'constants.py'
+
+sys.modules.setdefault('bradax', ModuleType('bradax'))
+
+spec = importlib.util.spec_from_file_location('bradax.constants', module_path)
+constants = importlib.util.module_from_spec(spec)
+sys.modules['bradax.constants'] = constants
+spec.loader.exec_module(constants)
+
+get_sdk_environment = constants.get_sdk_environment
+BradaxEnvironment = constants.BradaxEnvironment
+get_hub_url = constants.get_hub_url
+validate_project_id = constants.validate_project_id
+validate_api_key = constants.validate_api_key
+SDKNetworkConstants = constants.SDKNetworkConstants
+SDKSecurityConstants = constants.SDKSecurityConstants
+SDKValidationConstants = constants.SDKValidationConstants
+
+
+def test_get_sdk_environment_default(monkeypatch):
+    monkeypatch.delenv('BRADAX_ENV', raising=False)
+    assert get_sdk_environment() == BradaxEnvironment.DEVELOPMENT
+
+
+def test_get_sdk_environment_override(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'staging')
+    assert get_sdk_environment() == BradaxEnvironment.STAGING
+
+
+def test_get_hub_url_for_env(monkeypatch):
+    monkeypatch.setenv('BRADAX_ENV', 'production')
+    importlib.reload(constants)
+    assert get_hub_url() == SDKNetworkConstants.PRODUCTION_HUB_URL
+
+
+def test_validate_project_id():
+    valid = f"{SDKValidationConstants.PROJECT_ID_PREFIX}abc12345"
+    assert validate_project_id(valid)
+    assert not validate_project_id('invalid')
+
+
+def test_validate_api_key():
+    valid = f"{SDKSecurityConstants.API_KEY_PREFIX}" + 'a'*32
+    assert validate_api_key(valid)
+    assert not validate_api_key('bad')


### PR DESCRIPTION
## Summary
- add compatibility alias and factory in corporate client
- expose helper functions to manage global SDK config
- add unit tests for SDK constants and config
- add broker tests for config, constants and OpenAI service
- fix middleware syntax and main configuration names

## Testing
- `PYTHONPATH=bradax-sdk/src:bradax-broker/src pytest bradax-sdk/tests bradax-broker/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b655b2cc8327a59ef025d9e23cbe